### PR TITLE
feat(caching): Add Nginx config and Lua code for caching Grafana queries

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM openresty/openresty:1.21.4.3-bullseye-fat
+
+RUN apt update && apt install -y git && \
+    opm get ledgetech/lua-resty-http
+
+ENV LUA_CPATH="/usr/local/openresty/lualib/?.so;/usr/local/openresty/site/lualib/?.so;"
+ENV LUA_PATH="/usr/local/openresty/lualib/?.lua;/usr/local/openresty/site/lualib/?.lua;"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "./Dockerfile"
+	},
+	// "image": "openresty/openresty:1.21.4.3-bullseye-fat",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"sumneko.lua"
+			]
+		}
+	}
+	// "containerEnv": {
+	// 	"LUA_CPATH": "/usr/local/openresty/lualib/?.so",
+	// 	"LUA_PATH": "/usr/local/openresty/lualib/?.lua"
+	// }
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openresty/openresty:1.21.4.3-bullseye-fat
+
+
+RUN mkdir -p /var/lib/nginx/cache && \
+    rm /etc/nginx/conf.d/default.conf || true && \
+    opm get ledgetech/lua-resty-http
+
+COPY nginx/grafana.conf nginx/grafana_request.lua /etc/nginx/conf.d/
+
+ENV LUA_CPATH="/usr/local/openresty/lualib/?.so;/usr/local/openresty/site/lualib/?.so;"
+ENV LUA_PATH="/usr/local/openresty/lualib/?.lua;/usr/local/openresty/site/lualib/?.lua;/etc/nginx/conf.d/?.lua;"

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,8 @@
+# Bad
+* extra call for auth
+
+
+# Recommended Query changes
+* use of _time_filter function
+* use of now() for current time
+* pre defined time ranges

--- a/grafana.conf
+++ b/grafana.conf
@@ -1,0 +1,176 @@
+proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=grafana_query_cache:10m inactive=500m;
+log_format log_including_cache_key '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for" \'"$upstream_cache_status" "$cache_key" "$cache_access_denied"\'';
+
+upstream grafana_server {
+    server grafana:3000;
+}
+
+map $upstream_cache_status $cache_found {
+    HIT     1;
+    default 0; 
+}
+
+map $remote_addr $cache_status_header { 
+    127.0.0.1       $upstream_cache_status;
+    default         "";
+}
+
+map $remote_addr $cache_key_header { 
+    127.0.0.1       $cache_key;
+    default         "";
+}
+
+map $remote_addr $cache_access_denied_header { 
+    127.0.0.1       $cache_access_denied;
+    default         "";
+}
+
+# if cache_key is empty then no cache
+map $cache_key  $empty_cache_key { 
+    ""          1;
+    default     0;
+}
+
+# this is required to proxy Grafana Live WebSocket connections.
+map $http_upgrade $connection_upgrade {
+  default   upgrade;
+  ''        close;
+}
+
+
+server {
+    listen       3000 default_server;
+    server_name  _;
+    
+    # https://github.com/openresty/openresty/blob/master/t/001-resolver.t#L20
+    # https://github.com/openresty/lua-resty-redis/issues/159#issuecomment-460101005
+    resolver local=on;
+    location /api/ds/query {
+        access_log          /usr/local/openresty/nginx/logs/access.log log_including_cache_key;
+
+        proxy_cache         grafana_query_cache;
+        proxy_cache_methods POST;
+        proxy_cache_valid   200 60m;
+
+        # to prevent multiple requests going to origin server immediate after cache expiring
+        proxy_cache_lock            on;
+        proxy_cache_lock_timeout    10s;
+
+        # return old cached response if the cache is updating or proxy_cache_lock_timeout is reached
+        proxy_cache_use_stale   updating    timeout;
+        proxy_cache_revalidate  off;
+
+        # debug headers will only work if host = localhost
+        add_header      X-Cache-Status          $cache_status_header;        
+        add_header      X-Cache-Key             $cache_key_header;
+        add_header      X-Cache-Access-Denied   $cache_access_denied_header;
+
+
+        # for testing read request body from file
+        # client_body_in_file_only clean;
+
+        set $cache_key          "";
+        set $cache_access_denied    0;
+        # set_by_lua_block $cache_key {
+        rewrite_by_lua_block {
+            function get_cache_key()
+                local grafana_request = require "grafana_request"
+                local body_data = get_body_data()
+                if not body_data then
+                    -- no caching
+                    ngx.var.cache_key = ""
+                    return
+                end
+                local cache_key, datasource_uids = grafana_request.get_cache_key_and_datasource_uids(body_data)
+                if type(cache_key) ~= "string" or string.len(cache_key) == 0 or type(datasource_uids) ~= "table" or #datasource_uids == 0 then
+                    ngx.log(ngx.STDERR, type(cache_key), type(datasource_uids))
+                    error("empty cache key or empty datasource_uids table")
+                    return
+                end
+
+                local cookie_header = ngx.req.get_headers()["Cookie"]
+                if not cookie_header then
+                    cookie_header = ""
+                end
+                local authorization_header = ngx.req.get_headers()["Authorization"]
+                if not authorization_header then
+                    authorization_header = ""
+                end
+
+                local user_access = check_user_access("http://grafana:3000", datasource_uids, cookie_header, authorization_header)
+                if user_access == false then
+                    ngx.var.cache_access_denied = 1
+                end
+
+                ngx.var.cache_key = cache_key
+                ngx.log(ngx.STDERR, "cache key: ", ngx.var.cache_key)
+            end
+
+            function error_handler(err) 
+                ngx.log(ngx.STDERR, "failed to generate cache key: ", err)
+                ngx.var.cache_key = ""
+            end
+
+            function get_body_data() 
+                ngx.req.read_body() 
+                local body_data = ngx.req.get_body_data()
+                if not body_data then
+                    -- try reading body file
+                    local body_file = ngx.req.get_body_file()
+                    if body_file then
+                        -- we are not checking the body size before reading it into memory
+                        -- we should set max request size in nginx config
+                        -- todo document above somewhere
+                        local file = io.open(body_file, "rb")
+                        if not file then
+                            ngx.log(ngx.STDERR, "unable to open request file")
+                            return nil
+                        end
+                        body_data = file:read("*all")
+                    else
+                        ngx.log(ngx.STDERR, "unable to get request body")
+                        return nil
+                    end
+                end
+                return body_data
+            end
+
+            function entrypoint() 
+                local cache_key = get_cache_key()
+                if string.len(cache_key) == 0 then
+                    error("empty cache key")
+                end
+                
+            end
+
+            xpcall(get_cache_key, error_handler)
+        }
+        proxy_cache_key     $cache_key;
+        proxy_no_cache      $empty_cache_key;
+        proxy_cache_bypass  $cache_access_denied;
+
+        proxy_set_header    Host    $http_host;
+        proxy_pass          http://grafana_server;
+        
+        # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers
+        # cache-control header is set to no-store by grafana which avoids caching
+        proxy_ignore_headers    Cache-Control;
+        proxy_hide_header       Cache-Control;
+        add_header              Cache-Control   "private, max-age=3600";
+    }
+
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_pass  http://grafana_server;
+    }
+
+    # Proxy Grafana Live WebSocket connections.
+    location /api/live/ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $http_host;
+        proxy_pass http://grafana_server;
+    }
+
+}

--- a/grafana_request.lua
+++ b/grafana_request.lua
@@ -1,0 +1,181 @@
+local requestBody = [[
+  {
+      "from": "1703631956991",
+      "to": "1703653556991",
+      "queries": [
+        {
+          "refId": "FundCategory",
+          "datasource": {
+            "type": "postgres",
+            "uid": "cebc8c1a-8a2c-4b65-8352-f0cb1982615a"
+          },
+          "rawSql": "select distinct COALESCE(NULLIF(category, ''), 'unknown') from funds;",
+          "format": "table"
+        },
+        {
+          "refId": "FundCategory",
+          "datasource": {
+            "type": "postgres",
+            "uid": "cebc8c1a-8a2c-4b65-8352-f0cb1982615a"
+          },
+          "rawSql": "select distinct COALESCE(NULLIF(category, ''), 'unknown') from funds;",
+          "format": "table"
+        }
+      ]
+    }
+]]
+local json = require "cjson";
+local resty_md5 = require "resty.md5";
+local resty_string = require "resty.string";
+
+
+-- luarocks install lua-resty-http
+-- 30 mins
+local time_bucket_length_ms = 30 * 60 * 1000;
+-- 10 mins
+local time_frame_bucket_length_ms = 10 * 60 * 1000;
+
+
+local function get_datasource_uids(queries)
+  -- to avoid duplicates
+  local data_source_already_added = {}
+  local data_sources = {}
+  for _, query in pairs(queries) do
+    if type(query.datasource) ~= "table" and type(query.datasource.uid) ~= "string" and string.len(query.datasource.uid) ~= 0 then
+      error("invalid request body, unable to get datasource uid")
+      return
+    end
+    if not data_source_already_added[query.datasource.uid] then
+      table.insert(data_sources, query.datasource.uid)
+      data_source_already_added[query.datasource.uid] = true
+    end
+  end
+  return data_sources
+end
+
+local function tomd5(input)
+  -- -- todo remove this
+  -- return input
+  local md5 = resty_md5:new()
+    if not md5 then
+        error("failed to create md5 object")
+        return
+    end
+
+    local ok = md5:update(input)
+    if not ok then
+        error("failed to add data to md5")
+        return
+    end
+    return resty_string.to_hex(md5:final())
+end
+
+-- cache_key, property_name and property_value should be strings
+-- returns the new cache key after adding the mentioned property
+local function add_property_in_cache_key(cache_key, property_name, property_value)
+  if string.len(cache_key) ~= 0 then
+    cache_key = cache_key .. ";"
+  end
+  cache_key = cache_key .. string.format("%s=%s", property_name, property_value)
+  return cache_key
+end
+
+local function get_grafana_query_cache_key(to, from, queries)
+  local cache_key = ""
+
+  local time_bucket_number = math.floor(
+    tonumber(to) / time_bucket_length_ms
+  )
+  cache_key = add_property_in_cache_key(cache_key, "time_bucket_number", tostring(time_bucket_number))
+
+  local time_frame_bucket_number = math.floor(
+    (tonumber(to) - tonumber(from)) / time_frame_bucket_length_ms
+  )
+  cache_key = add_property_in_cache_key(cache_key, "time_frame_bucket_number", tostring(time_frame_bucket_number))
+
+  local queries = tomd5(json.encode(queries))
+  cache_key = add_property_in_cache_key(cache_key, "queries", queries)
+
+  return cache_key
+end
+
+
+function get_cache_key_and_datasource_uids(request_body)
+  local parsed_request_body = json.decode(request_body)
+  if type(parsed_request_body) ~= "table" or tonumber(parsed_request_body.to) == nil or tonumber(parsed_request_body.from) == nil or type(parsed_request_body.queries) ~= "table" then
+    return error("invalid request body")
+  end
+  local cache_key = get_grafana_query_cache_key(parsed_request_body.to, parsed_request_body.from,
+    parsed_request_body.queries)
+  -- print(#parsed_request_body.queries)
+  local data_sources = get_datasource_uids(parsed_request_body.queries)
+  return cache_key, data_sources
+end
+
+--- check_user_access returns true if the user has access to all the datasources
+--- @param grafana_base_url string
+--- @param data_sources table
+--- @param cookie_header_value string
+--- @param authorization_header_value string
+---@return boolean
+function check_user_access(grafana_base_url, data_sources, cookie_header_value, authorization_header_value)
+  local http = require "resty.http"
+  local http_client = http.new()
+
+  if string.len(grafana_base_url) == 0 then
+    error("")
+    return false
+  end
+
+  for _, data_source in pairs(data_sources) do
+    local request_url = grafana_base_url
+    if request_url:sub(-1) == "/" then
+      request_url = request_url .. "/"
+    end
+    request_url = request_url .. string.format("/api/datasources/uid/%s/health", data_source)
+    ngx.log(ngx.STDERR, "auth_request url", request_url)
+
+    local request_headeres = {}
+    if string.len(cookie_header_value) ~= 0 then
+      request_headeres["Cookie"] = cookie_header_value
+    end
+    if string.len(authorization_header_value) ~= 0 then
+      request_headeres["Authorization"] = cookie_header_value
+    end
+
+    local res, err = http_client:request_uri(request_url, {
+      method = "GET",
+      headers = request_headeres
+    })
+    if err ~= nil or res == nil then
+      ngx.log(ngx.STDERR, err, res)
+      return false
+    end
+    ngx.log(ngx.STDERR, "auth_requst response status", res.status)
+    if res.status == nil or type(res.status) ~= "number" or res.status ~= 200 then
+      return false
+    end
+  end
+  return true
+end
+
+xpcall(function()
+  local cache_key, data_sources = get_cache_key_and_datasource_uids(requestBody)
+  if type(cache_key) ~= "string" or type(data_sources) ~= "table" then
+    error("received nil data from get_cache_key_and_datasource_uids")
+    return
+  end
+  print(cache_key)
+  for _, datasource in pairs(data_sources) do
+    print(datasource)
+  end
+end, function(err)
+  print("failed", err)
+end)
+
+
+
+return {
+  get_cache_key_and_datasource_uids = get_cache_key_and_datasource_uids,
+  check_user_access = check_user_access
+}


### PR DESCRIPTION
## feat(caching): Add Nginx config and Lua code for caching Grafana queries
- Implement POC for caching Grafana queries using Nginx and Lua.
- Configure Nginx to intercept and cache Grafana API requests.
- Develop Lua code to manage cache logic and store cached responses.

## feat(tooling): Add Dockerfile and .devcontainer for local debugging

- Create Dockerfile to build a development environment with Nginx and Lua.
- Add .devcontainer directory for VS Code integration and debugging capabilities.