### PR TITLE
build(docker): base image and package version changes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,14 @@
-FROM openresty/openresty:1.21.4.3-bullseye-fat
+FROM openresty/openresty:1.25.3.1-0-bookworm-fat
 
-RUN apt update && apt install -y git luarocks && \
-    opm get ledgetech/lua-resty-http && \
-    luarocks install luaunit && luarocks install md5
+RUN apt update && apt install -y luarocks=3.8.0+dfsg1-1 gettext-base=0.21-12 git wget && \
+    opm get ledgetech/lua-resty-http=0.17.1 && \
+    luarocks install luaunit 3.4-1 && luarocks install md5 1.3-1
 
 # go lang for tests
 RUN wget https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -O /tmp/go1.21.5.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/go1.21.5.linux-amd64.tar.gz && \ 
-    rm /tmp/go1.21.5.linux-amd64.tar.gz && \
-    /usr/local/go/bin/go install -v golang.org/x/tools/cmd/goimports@latest golang.org/x/tools/gopls@latest
-
+    rm /tmp/go1.21.5.linux-amd64.tar.gz 
+    
 ENV PATH=$PATH:/usr/local/go/bin
 
 ENV LUA_CPATH="/usr/local/openresty/lualib/?.so;/usr/local/openresty/site/lualib/?.so;/usr/local/lib/lua/5.1/?.so;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM openresty/openresty:1.21.4.3-bullseye-fat
+FROM openresty/openresty:1.25.3.1-0-bookworm-fat
 
 RUN rm /etc/nginx/conf.d/default.conf || true && \
-    apt update && apt install -y luarocks && \
-    opm get ledgetech/lua-resty-http && \
-    luarocks install md5
+    apt update && apt install -y luarocks=3.8.0+dfsg1-1 gettext-base=0.21-12 && \
+    opm get ledgetech/lua-resty-http=0.17.1 && \
+    luarocks install md5 1.3-1 && \
+    apt-get remove -y --purge luarocks && apt autoremove -y
 
 COPY grafana_request.lua /usr/local/openresty/lualib
 COPY grafana.conf ssl-conf.sh /etc/nginx/templates/


### PR DESCRIPTION
- Upgraded base image to OpenResty with Nginx 1.25.
- Hardcoded package versions for apt and Lua package installations